### PR TITLE
Implemented account level manage feature.

### DIFF
--- a/src/main/java/com/haruhiism/bbs/command/manage/AccountLevelManagementCommand.java
+++ b/src/main/java/com/haruhiism/bbs/command/manage/AccountLevelManagementCommand.java
@@ -1,0 +1,22 @@
+package com.haruhiism.bbs.command.manage;
+
+import com.haruhiism.bbs.domain.ManagerLevel;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Setter
+public class AccountLevelManagementCommand {
+
+    @NotBlank(message = "Account ID cannot be empty.", groups = {AccountLevelManagementRequestValidationGroup.class, AccountLevelManagementSubmitValidationGroup.class})
+    private String id;
+
+    @NotNull(message = "Level cannot be null.", groups = {AccountLevelManagementSubmitValidationGroup.class})
+    private ManagerLevel levelName;
+
+    @NotNull(message = "Operation cannot be null.", groups = {AccountLevelManagementSubmitValidationGroup.class})
+    private AccountLevelManagementOperation operation;
+}

--- a/src/main/java/com/haruhiism/bbs/command/manage/AccountLevelManagementOperation.java
+++ b/src/main/java/com/haruhiism/bbs/command/manage/AccountLevelManagementOperation.java
@@ -1,0 +1,6 @@
+package com.haruhiism.bbs.command.manage;
+
+public enum AccountLevelManagementOperation {
+
+    GRANT, REVOKE
+}

--- a/src/main/java/com/haruhiism/bbs/command/manage/AccountLevelManagementRequestValidationGroup.java
+++ b/src/main/java/com/haruhiism/bbs/command/manage/AccountLevelManagementRequestValidationGroup.java
@@ -1,0 +1,4 @@
+package com.haruhiism.bbs.command.manage;
+
+public interface AccountLevelManagementRequestValidationGroup {
+}

--- a/src/main/java/com/haruhiism/bbs/command/manage/AccountLevelManagementSubmitValidationGroup.java
+++ b/src/main/java/com/haruhiism/bbs/command/manage/AccountLevelManagementSubmitValidationGroup.java
@@ -1,0 +1,4 @@
+package com.haruhiism.bbs.command.manage;
+
+public interface AccountLevelManagementSubmitValidationGroup {
+}

--- a/src/main/java/com/haruhiism/bbs/config/InterceptorConfig.java
+++ b/src/main/java/com/haruhiism/bbs/config/InterceptorConfig.java
@@ -39,7 +39,7 @@ public class InterceptorConfig implements WebMvcConfigurer {
 
         registry.addInterceptor(boardManagerInterceptor)
                 .addPathPatterns(
-                        "/manage/article",
+                        "/manage/article/**",
                         "/manage/comment");
 
         registry.addInterceptor(accountManagerInterceptor)

--- a/src/main/java/com/haruhiism/bbs/controller/AccountController.java
+++ b/src/main/java/com/haruhiism/bbs/controller/AccountController.java
@@ -1,7 +1,6 @@
 package com.haruhiism.bbs.controller;
 
 import com.haruhiism.bbs.command.account.*;
-import com.haruhiism.bbs.domain.AccountLevel;
 import com.haruhiism.bbs.domain.authentication.LoginSessionInfo;
 import com.haruhiism.bbs.domain.dto.*;
 import com.haruhiism.bbs.exception.auth.AuthenticationFailedException;
@@ -50,7 +49,7 @@ public class AccountController {
             return "account/register";
         }
 
-        accountService.registerAccount(new BoardAccountDTO(command), AccountLevel.NORMAL);
+        accountService.registerAccount(new BoardAccountDTO(command));
         HttpSession session = request.getSession();
         session.setAttribute(sessionAuthAttribute, accountService.loginAccount(
                 BoardAccountDTO.builder().userId(command.getUserid()).build(),

--- a/src/main/java/com/haruhiism/bbs/domain/ManagerLevel.java
+++ b/src/main/java/com/haruhiism/bbs/domain/ManagerLevel.java
@@ -1,10 +1,9 @@
 package com.haruhiism.bbs.domain;
 
-public enum AccountLevel {
+public enum ManagerLevel {
     /**
-     * NORMAL: normal user.
      * BOARD_MANAGER: board articles/comments manager.
      * ACCOUNT_MANAGER: account manager.
      */
-    NORMAL, BOARD_MANAGER, ACCOUNT_MANAGER
+    BOARD_MANAGER, ACCOUNT_MANAGER
 }

--- a/src/main/java/com/haruhiism/bbs/domain/dto/BoardAccountLevelDTO.java
+++ b/src/main/java/com/haruhiism/bbs/domain/dto/BoardAccountLevelDTO.java
@@ -1,6 +1,6 @@
 package com.haruhiism.bbs.domain.dto;
 
-import com.haruhiism.bbs.domain.AccountLevel;
+import com.haruhiism.bbs.domain.ManagerLevel;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,5 +11,5 @@ import java.util.List;
 public class BoardAccountLevelDTO {
 
     private String userId;
-    private List<AccountLevel> levels;
+    private List<ManagerLevel> levels;
 }

--- a/src/main/java/com/haruhiism/bbs/domain/entity/BoardAccountLevel.java
+++ b/src/main/java/com/haruhiism/bbs/domain/entity/BoardAccountLevel.java
@@ -1,6 +1,6 @@
 package com.haruhiism.bbs.domain.entity;
 
-import com.haruhiism.bbs.domain.AccountLevel;
+import com.haruhiism.bbs.domain.ManagerLevel;
 import lombok.*;
 
 import javax.persistence.*;
@@ -22,6 +22,6 @@ public class BoardAccountLevel {
     @NonNull
     @Enumerated(EnumType.STRING) // to store enum types as string value.
     @Column(name = "ACCOUNT_LEVEL")
-    private AccountLevel accountLevel;
+    private ManagerLevel accountLevel;
 
 }

--- a/src/main/java/com/haruhiism/bbs/interceptor/AccountManagerInterceptor.java
+++ b/src/main/java/com/haruhiism/bbs/interceptor/AccountManagerInterceptor.java
@@ -1,6 +1,6 @@
 package com.haruhiism.bbs.interceptor;
 
-import com.haruhiism.bbs.domain.AccountLevel;
+import com.haruhiism.bbs.domain.ManagerLevel;
 import com.haruhiism.bbs.domain.authentication.LoginSessionInfo;
 import com.haruhiism.bbs.domain.dto.BoardAccountDTO;
 import com.haruhiism.bbs.service.account.AccountService;
@@ -23,10 +23,10 @@ public class AccountManagerInterceptor implements HandlerInterceptor {
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         HttpSession session = request.getSession(false);
         LoginSessionInfo loginSessionInfo = (LoginSessionInfo) session.getAttribute("loginSessionInfo");
-        List<AccountLevel> levels = accountService.getAccountLevels(
+        List<ManagerLevel> levels = accountService.getAccountLevels(
                 BoardAccountDTO.builder().userId(loginSessionInfo.getUserID()).build()).getLevels();
 
-        if(levels.contains(AccountLevel.ACCOUNT_MANAGER)) {
+        if(levels.contains(ManagerLevel.ACCOUNT_MANAGER)) {
             return true;
         } else {
             response.sendRedirect("/manage/console");

--- a/src/main/java/com/haruhiism/bbs/interceptor/BoardManagerInterceptor.java
+++ b/src/main/java/com/haruhiism/bbs/interceptor/BoardManagerInterceptor.java
@@ -1,6 +1,6 @@
 package com.haruhiism.bbs.interceptor;
 
-import com.haruhiism.bbs.domain.AccountLevel;
+import com.haruhiism.bbs.domain.ManagerLevel;
 import com.haruhiism.bbs.domain.authentication.LoginSessionInfo;
 import com.haruhiism.bbs.domain.dto.BoardAccountDTO;
 import com.haruhiism.bbs.service.account.AccountService;
@@ -23,10 +23,10 @@ public class BoardManagerInterceptor implements HandlerInterceptor {
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         HttpSession session = request.getSession(false);
         LoginSessionInfo loginSessionInfo = (LoginSessionInfo) session.getAttribute("loginSessionInfo");
-        List<AccountLevel> levels = accountService.getAccountLevels(
+        List<ManagerLevel> levels = accountService.getAccountLevels(
                 BoardAccountDTO.builder().userId(loginSessionInfo.getUserID()).build()).getLevels();
 
-        if(levels.contains(AccountLevel.BOARD_MANAGER)) {
+        if(levels.contains(ManagerLevel.BOARD_MANAGER)) {
             return true;
         } else {
             response.sendRedirect("/manage/console");

--- a/src/main/java/com/haruhiism/bbs/repository/AccountLevelRepository.java
+++ b/src/main/java/com/haruhiism/bbs/repository/AccountLevelRepository.java
@@ -1,5 +1,6 @@
 package com.haruhiism.bbs.repository;
 
+import com.haruhiism.bbs.domain.ManagerLevel;
 import com.haruhiism.bbs.domain.entity.BoardAccount;
 import com.haruhiism.bbs.domain.entity.BoardAccountLevel;
 import org.springframework.data.repository.CrudRepository;
@@ -10,7 +11,9 @@ import java.util.List;
 @Repository
 public interface AccountLevelRepository extends CrudRepository<BoardAccountLevel, Long> {
 
-    public List<BoardAccountLevel> findAllByBoardAccount(BoardAccount account);
+    List<BoardAccountLevel> findAllByBoardAccount(BoardAccount account);
 
-    public void deleteAllByBoardAccount(BoardAccount boardAccount);
+    void deleteByBoardAccountAndAccountLevel(BoardAccount boardAccount, ManagerLevel level);
+    void deleteAllByBoardAccount(BoardAccount boardAccount);
+
 }

--- a/src/main/java/com/haruhiism/bbs/service/account/AccountService.java
+++ b/src/main/java/com/haruhiism/bbs/service/account/AccountService.java
@@ -1,6 +1,5 @@
 package com.haruhiism.bbs.service.account;
 
-import com.haruhiism.bbs.domain.AccountLevel;
 import com.haruhiism.bbs.domain.UpdatableInformation;
 import com.haruhiism.bbs.domain.authentication.LoginSessionInfo;
 import com.haruhiism.bbs.domain.dto.AuthDTO;
@@ -12,15 +11,15 @@ import com.haruhiism.bbs.exception.auth.AuthenticationFailedException;
 
 public interface AccountService {
 
-    public void registerAccount(BoardAccountDTO boardAccountDTO, AccountLevel level);
+    void registerAccount(BoardAccountDTO boardAccountDTO);
 
-    public void withdrawAccount(BoardAccountDTO boardAccountDTO, AuthDTO authDTO) throws AuthenticationFailedException;
+    void withdrawAccount(BoardAccountDTO boardAccountDTO, AuthDTO authDTO) throws AuthenticationFailedException;
 
-    public boolean isDuplicatedUserID(String userId);
+    boolean isDuplicatedUserID(String userId);
 
-    public LoginSessionInfo loginAccount(BoardAccountDTO boardAccountDTO, AuthDTO authDTO) throws AuthenticationFailedException;
+    LoginSessionInfo loginAccount(BoardAccountDTO boardAccountDTO, AuthDTO authDTO) throws AuthenticationFailedException;
 
-    public LoginSessionInfo updateAccount(BoardAccountDTO boardAccountDTO, AuthDTO authDTO, UpdatableInformation updatedField, String updatedValue) throws AuthenticationFailedException;
+    LoginSessionInfo updateAccount(BoardAccountDTO boardAccountDTO, AuthDTO authDTO, UpdatableInformation updatedField, String updatedValue) throws AuthenticationFailedException;
 
-    public BoardAccountLevelDTO getAccountLevels(BoardAccountDTO boardAccountDTO) throws NoAccountFoundException;
+    BoardAccountLevelDTO getAccountLevels(BoardAccountDTO boardAccountDTO) throws NoAccountFoundException;
 }

--- a/src/main/java/com/haruhiism/bbs/service/account/BasicAccountService.java
+++ b/src/main/java/com/haruhiism/bbs/service/account/BasicAccountService.java
@@ -1,6 +1,6 @@
 package com.haruhiism.bbs.service.account;
 
-import com.haruhiism.bbs.domain.AccountLevel;
+import com.haruhiism.bbs.domain.ManagerLevel;
 import com.haruhiism.bbs.domain.UpdatableInformation;
 import com.haruhiism.bbs.domain.authentication.LoginSessionInfo;
 import com.haruhiism.bbs.domain.dto.AuthDTO;
@@ -13,7 +13,6 @@ import com.haruhiism.bbs.exception.auth.AuthenticationFailedException;
 import com.haruhiism.bbs.repository.AccountLevelRepository;
 import com.haruhiism.bbs.repository.AccountRepository;
 import com.haruhiism.bbs.service.DataEncoder.DataEncoder;
-import com.haruhiism.bbs.service.article.ArticleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,12 +27,11 @@ public class BasicAccountService implements AccountService {
 
     private final AccountRepository accountRepository;
     private final AccountLevelRepository accountLevelRepository;
-    private final ArticleService articleService;
     private final DataEncoder dataEncoder;
 
 
     @Override
-    public void registerAccount(BoardAccountDTO boardAccountDTO, AccountLevel level) {
+    public void registerAccount(BoardAccountDTO boardAccountDTO) {
         BoardAccount boardAccount = new BoardAccount(
                 boardAccountDTO.getUserId(),
                 boardAccountDTO.getUsername(),
@@ -41,8 +39,6 @@ public class BasicAccountService implements AccountService {
                 boardAccountDTO.getEmail(),
                 true);
         accountRepository.save(boardAccount);
-
-        accountLevelRepository.save(new BoardAccountLevel(boardAccount, level));
     }
 
     @Override
@@ -95,7 +91,7 @@ public class BasicAccountService implements AccountService {
 
     @Override
     public BoardAccountLevelDTO getAccountLevels(BoardAccountDTO boardAccountDTO) throws NoAccountFoundException {
-        List<AccountLevel> userLevels = accountLevelRepository.findAllByBoardAccount(
+        List<ManagerLevel> userLevels = accountLevelRepository.findAllByBoardAccount(
                 accountRepository.findByUserIdAndAvailableTrue(boardAccountDTO.getUserId()).orElseThrow(NoAccountFoundException::new))
                 .stream().map(BoardAccountLevel::getAccountLevel).collect(Collectors.toList());
 

--- a/src/main/java/com/haruhiism/bbs/service/manage/AccountManagerService.java
+++ b/src/main/java/com/haruhiism/bbs/service/manage/AccountManagerService.java
@@ -1,6 +1,7 @@
 package com.haruhiism.bbs.service.manage;
 
 import com.haruhiism.bbs.domain.AccountSearchMode;
+import com.haruhiism.bbs.domain.ManagerLevel;
 import com.haruhiism.bbs.domain.dto.BoardAccountsDTO;
 
 import java.time.LocalDateTime;
@@ -11,6 +12,7 @@ public interface AccountManagerService {
     Long countAllAccounts();
 
     boolean authManagerAccess(String userId);
+    void changeManagerLevel(String userId, ManagerLevel level, boolean enable);
 
     BoardAccountsDTO readAccounts(int pageNum, int pageSize, LocalDateTime from, LocalDateTime to);
     BoardAccountsDTO searchAccounts(AccountSearchMode mode, String keyword, int pageNum, int pageSize, LocalDateTime from, LocalDateTime to);
@@ -19,6 +21,5 @@ public interface AccountManagerService {
     void restoreAccounts(List<Long> accountIds);
 
     void changePassword(List<Long> accountIds, String newPassword);
-
     void changeUsername(List<Long> accountIds, String newUsername);
 }

--- a/src/main/resources/templates/admin/account-console.html
+++ b/src/main/resources/templates/admin/account-console.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:th="http://www.thymeleaf.org" lang="ko">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org" lang="ko">
+
 <head>
-    <meta charset="UTF-8">
-    <title>Management Console - Account</title>
+  <meta charset="UTF-8">
+  <title>Management Console - Account</title>
 
 
   <style>
@@ -24,10 +24,11 @@
     }
 
     span.current {
-      font-weight:800;
+      font-weight: 800;
     }
   </style>
 </head>
+
 <body>
 
   <div>
@@ -47,48 +48,50 @@
 
   <br>
 
-<div id="accounts">
-  <form action="#" method="post">
-    <table>
-      <tr>
-        <th>ID</th>
-        <th>USERID</th>
-        <th>USERNAME</th>
-        <th>EMAIL</th>
-        <th>REGISTERED DATE</th>
-        <th>AVAILABLE</th>
-        <th>CHECK</th>
-      </tr>
+  <div id="accounts">
+    <form action="#" method="post">
+      <table>
+        <tr>
+          <th>ID</th>
+          <th>USERID</th>
+          <th>USERNAME</th>
+          <th>EMAIL</th>
+          <th>REGISTERED DATE</th>
+          <th>AVAILABLE</th>
+          <th>CHECK</th>
+          <th>PRIVILEGE</th>
+        </tr>
 
-      <tr th:each="account: ${accounts}">
-        <td th:text="${account.id}">0</td>
-        <td th:text="${account.userId}">UserID</td>
-        <td th:text="${account.username}">Username</td>
-        <td th:text="${account.email}">email@domain.com</td>
-        <td th:text="${account.registeredDate}">1970-01-01</td>
-        <td th:text="${account.available}">True</td>
-        <td><input name="target" type="checkbox" th:value="${account.id}"></td>
-      </tr>
-    </table>
+        <tr th:each="account: ${accounts}">
+          <td th:text="${account.id}">0</td>
+          <td th:text="${account.userId}">UserID</td>
+          <td th:text="${account.username}">Username</td>
+          <td th:text="${account.email}">email@domain.com</td>
+          <td th:text="${account.registeredDate}">1970-01-01</td>
+          <td th:text="${account.available}">True</td>
+          <td><input name="target" type="checkbox" th:value="${account.id}"></td>
+          <td><a th:href="@{/manage/console/account/level(id=${account.userId})}" th:text="CHANGE">/link/to/management</a></td>
+        </tr>
+      </table>
 
-    <div>
-      <label for="account-operation">MODE</label>
-      <select id="account-operation" name="operation">
-        <option value="CHANGE_PASSWORD">Change Password</option>
-        <option value="CHANGE_USERNAME">Change Username</option>
-        <option value="INVALIDATE">Invalidate</option>
-        <option value="RESTORE">Restore</option>
-      </select>
-      <input type="text" name="keyword" placeholder="Type value to change">
-      <input type="submit" value="OPERATE">
-    </div>
+      <div>
+        <label for="account-operation">MODE</label>
+        <select id="account-operation" name="operation">
+          <option value="CHANGE_PASSWORD">Change Password</option>
+          <option value="CHANGE_USERNAME">Change Username</option>
+          <option value="INVALIDATE">Invalidate</option>
+          <option value="RESTORE">Restore</option>
+        </select>
+        <input id="operation-value" type="text" name="keyword" placeholder="Type value to change">
+        <input type="submit" value="OPERATE">
+      </div>
 
-  </form>
+    </form>
 
-  <div th:if="${totalPages > 1}">
-        <span th:each="index: ${#numbers.sequence(1, totalPages)}" th:classappend="${index - 1 == currentPage} == true ? 'current' : ''">
-          <a
-                  th:href="@{/manage/console/account(
+    <div th:if="${totalPages > 1}">
+      <span th:each="index: ${#numbers.sequence(1, totalPages)}"
+        th:classappend="${index - 1 == currentPage} == true ? 'current' : ''">
+        <a th:href="@{/manage/console/account(
                   pageNum=${index - 1},
                   pageSize=${pageSize},
                   keyword=${keyword},
@@ -96,53 +99,54 @@
                   betweenDates=${betweenDates},
                   from=${from},
                   to=${to})}" th:text="${index}">0</a>
-        </span>
+      </span>
+    </div>
+
+    <br>
+
+    <div>
+      <form action="#" method="get">
+        <table>
+          <tr>
+            <td>
+              <label for="searchMode">SEARCH MODE</label>
+              <select id="searchMode" name="mode">
+                <option value="USERID" th:selected="${'USERID' eq mode}">UserID</option>
+                <option value="USERNAME" th:selected="${'USERNAME' eq mode}">Username</option>
+                <option value="EMAIL" th:selected="${'EMAIL' eq mode}">Email</option>
+              </select>
+            </td>
+            <td colspan="2">
+              <input id="keyword" type="text" name="keyword" th:value="${keyword}">
+            </td>
+            <td>
+              <a href="/manage/console/account">CLEAR</a>
+            </td>
+          </tr>
+
+          <tr>
+            <td>
+              <label for="search-date-checkbox">SEARCH BETWEEN DATES?</label>
+              <input id="search-date-checkbox" type="checkbox" name="betweenDates" th:checked="${betweenDates}">
+            </td>
+            <td>
+              <label for="from">FROM</label>
+              <input id="from" type="date" name="from" th:value="${from}">
+            </td>
+            <td>
+              <label for="to">TO</label>
+              <input id="to" type="date" name="to" th:value="${to}">
+            </td>
+            <td>
+              <input type="submit" value="SEARCH">
+            </td>
+          </tr>
+
+        </table>
+      </form>
+    </div>
   </div>
-
-  <br>
-
-  <div>
-    <form action="#" method="get">
-      <table>
-        <tr>
-          <td>
-            <label for="searchMode">SEARCH MODE</label>
-            <select id="searchMode" name="mode">
-              <option value="USERID" th:selected="${'USERID' eq mode}">UserID</option>
-              <option value="USERNAME" th:selected="${'USERNAME' eq mode}">Username</option>
-              <option value="EMAIL" th:selected="${'EMAIL' eq mode}">Email</option>
-            </select>
-          </td>
-          <td colspan="2">
-            <input id="keyword" type="text" name="keyword" th:value="${keyword}">
-          </td>
-          <td>
-            <a href="/manage/console/account">CLEAR</a>
-          </td>
-        </tr>
-
-        <tr>
-          <td>
-            <label for="search-date-checkbox">SEARCH BETWEEN DATES?</label>
-            <input id="search-date-checkbox" type="checkbox" name="betweenDates" th:checked="${betweenDates}">
-          </td>
-          <td>
-            <label for="from">FROM</label>
-            <input id="from" type="date" name="from" th:value="${from}">
-          </td>
-          <td>
-            <label for="to">TO</label>
-            <input id="to" type="date" name="to" th:value="${to}">
-          </td>
-          <td>
-            <input type="submit" value="SEARCH">
-          </td>
-        </tr>
-
-      </table>
-    </form>
-  </div>
-</div>
 
 </body>
+
 </html>

--- a/src/main/resources/templates/admin/account-level-console.html
+++ b/src/main/resources/templates/admin/account-level-console.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>Management Console - Account Level</title>
+</head>
+<body>
+
+<div>
+    <h1>ACCOUNT LEVEL MANAGEMENT CONSOLE</h1>
+</div>
+
+<div th:object="${command}">
+    <span th:text="|Account ID: *{id}|">Account ID: -</span>
+    <br>
+    <span th:if="${#fields.hasErrors('id')}" th:errors="*{id}">Id Error String</span>
+    <span th:if="${#fields.hasErrors('levelName')}" th:errors="*{levelName}">Id Error String</span>
+    <span th:if="${#fields.hasErrors('operation')}" th:errors="*{operation}">Id Error String</span>
+</div>
+
+<div>
+    <span>ACCOUNT LEVELS</span>
+    <table>
+        <tr th:each="level, index: ${levels}">
+            <td>
+                <span th:text="${index.index}">0</span>
+            </td>
+            <td>
+                <span th:text="${level}">LEVEL</span>
+            </td>
+            <td>
+                <form method="post" action="#">
+<!--                    <input type="hidden" name="id" th:value="${command.id}">-->
+                    <input type="hidden" name="levelName" th:value="${level}">
+                    <input type="submit" name="operation" value="GRANT" th:disabled="${accountLevels.contains(level)}">
+                </form>
+            </td>
+            <td>
+                <form method="post" action="#">
+<!--                    <input type="hidden" name="id" th:value="${command.id}">-->
+                    <input type="hidden" name="levelName" th:value="${level}">
+                    <input type="submit" name="operation" value="REVOKE" th:disabled="${!accountLevels.contains(level)}">
+                </form>
+            </td>
+        </tr>
+    </table>
+    <a href="/manage/console/account">BACK</a>
+</div>
+
+</body>
+</html>

--- a/src/test/java/com/haruhiism/bbs/mvc/AccountMvcTest.java
+++ b/src/test/java/com/haruhiism/bbs/mvc/AccountMvcTest.java
@@ -1,7 +1,6 @@
 package com.haruhiism.bbs.mvc;
 
 
-import com.haruhiism.bbs.domain.AccountLevel;
 import com.haruhiism.bbs.domain.UpdatableInformation;
 import com.haruhiism.bbs.domain.authentication.LoginSessionInfo;
 import com.haruhiism.bbs.domain.dto.AuthDTO;
@@ -140,8 +139,8 @@ public class AccountMvcTest {
     void submitInvalidWithdrawTest() throws Exception {
         // given
         accountService.registerAccount(
-                new BoardAccountDTO(testUserId, testUsername, testPassword, testEmail),
-                AccountLevel.NORMAL);
+                new BoardAccountDTO(testUserId, testUsername, testPassword, testEmail)
+        );
 
         LoginSessionInfo loginSessionInfo = accountService.loginAccount(
                 BoardAccountDTO.builder().userId(testUserId).build(),
@@ -165,8 +164,8 @@ public class AccountMvcTest {
     void submitInvalidLoginTest() throws Exception {
         // given
         accountService.registerAccount(
-                new BoardAccountDTO(testUserId, testUsername, testPassword, testEmail),
-                AccountLevel.NORMAL);
+                new BoardAccountDTO(testUserId, testUsername, testPassword, testEmail)
+        );
 
         HttpHeaders params = new HttpHeaders();
         params.set("userid", "");
@@ -205,8 +204,8 @@ public class AccountMvcTest {
     void submitInvalidInfoUpdateTest() throws Exception {
         // given
         accountService.registerAccount(
-                new BoardAccountDTO(testUserId, testUsername, testPassword, testEmail),
-                AccountLevel.NORMAL);
+                new BoardAccountDTO(testUserId, testUsername, testPassword, testEmail)
+        );
 
         MockHttpSession session = new MockHttpSession();
         session.setAttribute("loginSessionInfo", accountService.loginAccount(

--- a/src/test/java/com/haruhiism/bbs/service/AccountServiceTest.java
+++ b/src/test/java/com/haruhiism/bbs/service/AccountServiceTest.java
@@ -1,6 +1,5 @@
 package com.haruhiism.bbs.service;
 
-import com.haruhiism.bbs.domain.AccountLevel;
 import com.haruhiism.bbs.domain.UpdatableInformation;
 import com.haruhiism.bbs.domain.authentication.LoginSessionInfo;
 import com.haruhiism.bbs.domain.dto.AuthDTO;
@@ -47,7 +46,7 @@ class AccountServiceTest {
         // given
         BoardAccountDTO boardAccountDTO = new BoardAccountDTO(testUserId, testUsername, testPassword, testEmail);
         // when
-        accountService.registerAccount(boardAccountDTO, AccountLevel.NORMAL);
+        accountService.registerAccount(boardAccountDTO);
         // then
         assertFalse(accountRepository.findByUserIdAndAvailableTrue(testUserId).isEmpty());
 
@@ -84,7 +83,7 @@ class AccountServiceTest {
     void withdrawAccountTest() {
         // given
         BoardAccountDTO boardAccountDTO = new BoardAccountDTO(testUserId, testUsername, testPassword, testEmail);
-        accountService.registerAccount(boardAccountDTO, AccountLevel.NORMAL);
+        accountService.registerAccount(boardAccountDTO);
 
         // when
         accountService.withdrawAccount(
@@ -107,7 +106,7 @@ class AccountServiceTest {
     void loginAccountTest() {
         // given
         BoardAccountDTO boardAccountDTO = new BoardAccountDTO(testUserId, testUsername, testPassword, testEmail);
-        accountService.registerAccount(boardAccountDTO, AccountLevel.NORMAL);
+        accountService.registerAccount(boardAccountDTO);
 
         // when
         assertThrows(AuthenticationFailedException.class, () -> {
@@ -142,7 +141,7 @@ class AccountServiceTest {
     void updateUsernameTest() {
         // given
         BoardAccountDTO boardAccountDTO = new BoardAccountDTO(testUserId, testUsername, testPassword, testEmail);
-        accountService.registerAccount(boardAccountDTO, AccountLevel.NORMAL);
+        accountService.registerAccount(boardAccountDTO);
 
         // when
         accountService.updateAccount(
@@ -162,7 +161,7 @@ class AccountServiceTest {
     void updateEmailTest() {
         // given
         BoardAccountDTO boardAccountDTO = new BoardAccountDTO(testUserId, testUsername, testPassword, testEmail);
-        accountService.registerAccount(boardAccountDTO, AccountLevel.NORMAL);
+        accountService.registerAccount(boardAccountDTO);
 
         // when
         accountService.updateAccount(
@@ -182,7 +181,7 @@ class AccountServiceTest {
     void updatePasswordTest() {
         // given
         BoardAccountDTO boardAccountDTO = new BoardAccountDTO(testUserId, testUsername, testPassword, testEmail);
-        accountService.registerAccount(boardAccountDTO, AccountLevel.NORMAL);
+        accountService.registerAccount(boardAccountDTO);
 
         // when
         accountService.updateAccount(


### PR DESCRIPTION
# Purpose
- 회원 등급은 NORMAL을 제거하고 관리자 등급으로 변경.
- 회원 관리자가 다른 회원들의 등급을 변경할 수 있는 기능을 구현.
- 회원가입 시 아무런 등급(NORMAL)도 등록하지 않음.

# etc
- 회원 등급 변경 URL이 GET 파라미터로 해당 회원의 ID를 가리키기 때문에 POST 시에도 중복으로 전달됨.
- 그래서 form에서는 ID를 따로 전달하지 않지만 만약 URL이 변경된다면 다른 ID로 동작하게 될 수도 있음.
- 그러나 관리자 페이지기 때문에 별다른 조건을 추가하지 않음.